### PR TITLE
Debugging Multi range log addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ JanusGraph, coupled with the FoundationDB storage adapter provides the following
 |FDB Storage Adapter|JanusGraph|FoundationDB|
 |-:|-:|-:|
 |0.1.0|0.3.0|5.2.5|
+|0.2.0|0.4.0|6.2.7|
+
 
 # Getting started
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <maven.compiler.plugin.version>3.6.2</maven.compiler.plugin.version>
         <jdk.version>1.8</jdk.version>
-        <janusgraph.version>0.3.0</janusgraph.version>
-        <foundationdb.version>5.2.5</foundationdb.version>
+        <janusgraph.version>0.4.0</janusgraph.version>
+        <foundationdb.version>6.2.10</foundationdb.version>
         <dependency.plugin.version>2.10</dependency.plugin.version>
         <test.skip.default>false</test.skip.default>
         <test.skip.tp>true</test.skip.tp>
@@ -66,10 +66,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.apple</groupId>
-            <artifactId>foundationdb</artifactId>
+            <groupId>org.foundationdb</groupId>
+            <artifactId>fdb-java</artifactId>
             <version>${foundationdb.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.palantir.docker.compose</groupId>
             <artifactId>docker-compose-rule-junit4</artifactId>

--- a/src/main/java/com/experoinc/janusgraph/diskstorage/foundationdb/FoundationDBTx.java
+++ b/src/main/java/com/experoinc/janusgraph/diskstorage/foundationdb/FoundationDBTx.java
@@ -232,6 +232,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
             } catch (IllegalStateException is) {
                 // illegal state can arise from tx being closed while tx is inflight
             } catch (Exception e) {
+                log.error("failed to get multi range for queries {}", queries, e);
                 throw new PermanentBackendException(e);
             }
         }


### PR DESCRIPTION
Trying to debug
janusgraph.log:org.janusgraph.core.JanusGraphException: Could not execute operation due to backend exception
janusgraph.log-	at org.janusgraph.diskstorage.util.BackendOperation.execute(BackendOperation.java:56)
janusgraph.log-	at org.janusgraph.diskstorage.BackendTransaction.executeRead(BackendTransaction.java:469)
janusgraph.log-	at org.janusgraph.diskstorage.BackendTransaction.edgeStoreMultiQuery(BackendTransaction.java:284)
janusgraph.log-	at org.janusgraph.graphdb.database.StandardJanusGraph.edgeMultiQuery(StandardJanusGraph.java:450)
janusgraph.log-	at org.janusgraph.graphdb.transaction.StandardJanusGraphTx.lambda$executeMultiQuery$5(StandardJanusGraphTx.java:1108)
janusgraph.log-	at org.janusgraph.graphdb.query.profile.QueryProfiler.profile(QueryProfiler.java:99)
janusgraph.log-	at org.janusgraph.graphdb.query.profile.QueryProfiler.profile(QueryProfiler.java:91)
janusgraph.log-	at org.janusgraph.graphdb.transaction.StandardJanusGraphTx.executeMultiQuery(StandardJanusGraphTx.java:1108)
janusgraph.log-	at org.janusgraph.graphdb.query.vertex.MultiVertexCentricQueryBuilder.execute(MultiVertexCentricQueryBuilder.java:113)
janusgraph.log-	at org.janusgraph.graphdb.query.vertex.MultiVertexCentricQueryBuilder.properties(MultiVertexCentricQueryBuilder.java:140)
janusgraph.log-	at org.janusgraph.graphdb.tinkerpop.optimize.JanusGraphPropertiesStep.initializeMultiQuery(JanusGraphPropertiesStep.java:113)
janusgraph.log-	at org.janusgraph.graphdb.tinkerpop.optimize.JanusGraphPropertiesStep.initialize(JanusGraphPropertiesStep.java:98)
janusgraph.log-	at org.janusgraph.graphdb.tinkerpop.optimize.JanusGraphPropertiesStep.processNextStart(JanusGraphPropertiesStep.java:124)
janusgraph.log-	at org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep.hasNext(AbstractStep.java:143)
janusgraph.log-	at org.apache.tinkerpop.gremlin.process.traversal.step.util.ExpandableStepIterator.next(ExpandableStepIterator.java:50)
janusgraph.log-	at org.apache.tinkerpop.gremlin.process.traversal.step.map.MapStep.processNextStart(MapStep.java:36)
janusgraph.log-	at org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectOneStep.processNextStart(SelectOneStep.java:131)
janusgraph.log-	at org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep.hasNext(AbstractStep.java:143)
janusgraph.log-	at org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal.hasNext(DefaultTraversal.java:192)
janusgraph.log-	at org.apache.tinkerpop.gremlin.server.util.TraverserIterator.fillBulker(TraverserIterator.java:69)
janusgraph.log-	at org.apache.tinkerpop.gremlin.server.util.TraverserIterator.hasNext(TraverserIterator.java:56)
janusgraph.log-	at org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor.handleIterator(TraversalOpProcessor.java:483)
janusgraph.log-	at org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor.lambda$iterateBytecodeTraversal$4(TraversalOpProcessor.java:382)
janusgraph.log-	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
janusgraph.log-	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
janusgraph.log-	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
janusgraph.log-	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
janusgraph.log-	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
janusgraph.log-	at java.lang.Thread.run(Thread.java:748)
janusgraph.log-Caused by: org.janusgraph.diskstorage.PermanentBackendException: Permanent failure in storage backend
janusgraph.log-	at com.experoinc.janusgraph.diskstorage.foundationdb.FoundationDBKeyValueStore.getSlices(FoundationDBKeyValueStore.java:204)
janusgraph.log-	at org.janusgraph.diskstorage.keycolumnvalue.keyvalue.OrderedKeyValueStoreAdapter.getSlice(OrderedKeyValueStoreAdapter.java:78)
janusgraph.log-	at org.janusgraph.diskstorage.keycolumnvalue.KCVSProxy.getSlice(KCVSProxy.java:81)
janusgraph.log-	at org.janusgraph.diskstorage.BackendTransaction$2.call(BackendTransaction.java:287)
janusgraph.log-	at org.janusgraph.diskstorage.BackendTransaction$2.call(BackendTransaction.java:284)
janusgraph.log-	at org.janusgraph.diskstorage.util.BackendOperation.executeDirect(BackendOperation.java:68)
janusgraph.log-	at org.janusgraph.diskstorage.util.BackendOperation.execute(BackendOperation.java:54)
janusgraph.log-	... 28 more
janusgraph.log-Caused by: org.janusgraph.diskstorage.PermanentBackendException: Permanent failure in storage backend
janusgraph.log-	at com.experoinc.janusgraph.diskstorage.foundationdb.FoundationDBTx.getMultiRange(FoundationDBTx.java:232)
janusgraph.log-	at com.experoinc.janusgraph.diskstorage.foundationdb.FoundationDBKeyValueStore.getSlices(FoundationDBKeyValueStore.java:191)
janusgraph.log-	... 34 more
janusgraph.log-Caused by: java.lang.InterruptedException
janusgraph.log-	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:347)
janusgraph.log-	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
janusgraph.log-	at com.experoinc.janusgraph.diskstorage.foundationdb.FoundationDBTx.getMultiRange(FoundationDBTx.java:226)
janusgraph.log-	... 35 more